### PR TITLE
Add in `ActionsVariable` resource

### DIFF
--- a/samples/basic/main.bicep
+++ b/samples/basic/main.bicep
@@ -39,5 +39,13 @@ resource secret 'ActionsSecret' = {
   value: 'super-secret-value'
 }
 
+resource variable 'ActionsVariable' = {
+  owner: owner
+  repo: repoName
+  name: 'MY_VARIABLE'
+  value: 'just-another-value'
+}
+
 output repo object = repo
 output collaborator object = collaborator
+output variable object = variable

--- a/src/Bicep.Extension.GitHub/Handlers/ActionsVariableResourceHandler.cs
+++ b/src/Bicep.Extension.GitHub/Handlers/ActionsVariableResourceHandler.cs
@@ -36,10 +36,20 @@ public class ActionsVariableResourceHandler : IResourceHandler
         => RequestHelper.HandleRequest(request.Config, async client => {
             var properties = RequestHelper.GetProperties<Types.Github.Models.ActionsVariable>(request.Properties);
 
-            await client.Repository.Actions.Variables.Create(
-                properties.Owner,
-                properties.Repo,
-                new(properties.Name, properties.Value));
+            try
+            {
+                await client.Repository.Actions.Variables.Create(
+                    properties.Owner,
+                    properties.Repo,
+                    new(properties.Name, properties.Value));
+            }
+            catch (ApiException ex) when (ex is { StatusCode: System.Net.HttpStatusCode.Conflict })
+            {
+                await client.Repository.Actions.Variables.Update(
+                    properties.Owner,
+                    properties.Repo,
+                    new(properties.Name, properties.Value));
+            }
 
             return RequestHelper.CreateSuccessResponse(request, properties, new Identifiers(properties.Owner, properties.Repo, properties.Name));
         });

--- a/src/Bicep.Extension.GitHub/Handlers/ActionsVariableResourceHandler.cs
+++ b/src/Bicep.Extension.GitHub/Handlers/ActionsVariableResourceHandler.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Bicep.Local.Extension.Protocol;
+using Octokit;
+using Sodium;
+
+namespace Bicep.Extension.Github.Handlers;
+
+public class ActionsVariableResourceHandler : IResourceHandler
+{
+    public string ResourceType => "ActionsVariable";
+
+    private record Identifiers(
+        string? Owner,
+        string? Repo,
+        string? Name);
+
+    public Task<LocalExtensibilityOperationResponse> Delete(ResourceReference request, CancellationToken cancellationToken)
+        => throw new NotImplementedException();
+
+    public Task<LocalExtensibilityOperationResponse> Get(ResourceReference request, CancellationToken cancellationToken)
+        => throw new NotImplementedException();
+
+    public Task<LocalExtensibilityOperationResponse> Preview(ResourceSpecification request, CancellationToken cancellationToken)
+        => RequestHelper.HandleRequest(request.Config, async client => {
+            var properties = RequestHelper.GetProperties<Types.Github.Models.ActionsVariable>(request.Properties);
+
+            await Task.Yield();
+
+            return RequestHelper.CreateSuccessResponse(request, properties, new Identifiers(properties.Owner, properties.Repo, properties.Name));
+        });
+
+    public Task<LocalExtensibilityOperationResponse> CreateOrUpdate(ResourceSpecification request, CancellationToken cancellationToken)
+        => RequestHelper.HandleRequest(request.Config, async client => {
+            var properties = RequestHelper.GetProperties<Types.Github.Models.ActionsVariable>(request.Properties);
+
+            await client.Repository.Actions.Variables.Create(
+                properties.Owner,
+                properties.Repo,
+                new(properties.Name, properties.Value));
+
+            return RequestHelper.CreateSuccessResponse(request, properties, new Identifiers(properties.Owner, properties.Repo, properties.Name));
+        });
+}

--- a/src/Bicep.Extension.GitHub/Program.cs
+++ b/src/Bicep.Extension.GitHub/Program.cs
@@ -25,7 +25,8 @@ public static class Program
         .AddHandler(new RepositoryResourceHandler())
         .AddHandler(new CollaboratorResourceHandler())
         .AddHandler(new LabelResourceHandler())
-        .AddHandler(new ActionsSecretResourceHandler());
+        .AddHandler(new ActionsSecretResourceHandler())
+        .AddHandler(new ActionsVariableResourceHandler());
 }
 
 public class KestrelProviderExtension : ProviderExtension

--- a/src/Bicep.Types.GitHub/Models/Models.cs
+++ b/src/Bicep.Types.GitHub/Models/Models.cs
@@ -99,3 +99,18 @@ public class ActionsSecret
     [TypeAnnotation("The secret value", ObjectTypePropertyFlags.Required, isSecure: true)]
     public string? Value { get; set; }
 }
+
+public class ActionsVariable
+{
+    [TypeAnnotation("The owner of the repository", ObjectTypePropertyFlags.Identifier | ObjectTypePropertyFlags.Required)]
+    public string? Owner { get; set; }
+
+    [TypeAnnotation("The repository", ObjectTypePropertyFlags.Identifier | ObjectTypePropertyFlags.Required)]
+    public string? Repo { get; set; }
+
+    [TypeAnnotation("The variable name", ObjectTypePropertyFlags.Identifier | ObjectTypePropertyFlags.Required)]
+    public string? Name { get; set; }
+
+    [TypeAnnotation("The variable value", ObjectTypePropertyFlags.Required, isSecure: false)]
+    public string? Value { get; set; }
+}

--- a/src/Bicep.Types.GitHub/TypeGenerator.cs
+++ b/src/Bicep.Types.GitHub/TypeGenerator.cs
@@ -117,6 +117,7 @@ public static class TypeGenerator
             GenerateResource(factory, typeCache, typeof(Collaborator)),
             GenerateResource(factory, typeCache, typeof(Label)),
             GenerateResource(factory, typeCache, typeof(ActionsSecret)),
+            GenerateResource(factory, typeCache, typeof(ActionsVariable)),
         };
 
         var index = new TypeIndex(

--- a/types/index.json
+++ b/types/index.json
@@ -11,6 +11,9 @@
     },
     "ActionsSecret": {
       "$ref": "types.json#/15"
+    },
+    "ActionsVariable": {
+      "$ref": "types.json#/17"
     }
   },
   "resourceFunctions": {},

--- a/types/types.json
+++ b/types/types.json
@@ -262,5 +262,52 @@
     },
     "flags": 0,
     "functions": null
+  },
+  {
+    "$type": "ObjectType",
+    "name": "ActionsVariable",
+    "properties": {
+      "owner": {
+        "type": {
+          "$ref": "#/2"
+        },
+        "flags": 17,
+        "description": "The owner of the repository"
+      },
+      "repo": {
+        "type": {
+          "$ref": "#/2"
+        },
+        "flags": 17,
+        "description": "The repository"
+      },
+      "name": {
+        "type": {
+          "$ref": "#/2"
+        },
+        "flags": 17,
+        "description": "The variable name"
+      },
+      "value": {
+        "type": {
+          "$ref": "#/2"
+        },
+        "flags": 1,
+        "description": "The variable value"
+      }
+    },
+    "additionalProperties": null,
+    "sensitive": null
+  },
+  {
+    "$type": "ResourceType",
+    "name": "ActionsVariable",
+    "scopeType": 0,
+    "readOnlyScopes": null,
+    "body": {
+      "$ref": "#/16"
+    },
+    "flags": 0,
+    "functions": null
   }
 ]


### PR DESCRIPTION
- Resource for adding repository variables
- Close clone of actions secrets, but no `CreateOrUpdate` available in Octokit so had to catch the exception on create and update instead
- Added in resource in bicep sample
- Generated new types
- Tested on a repository of my own with artifacts published to a ACR in my subscription

Screenshot
<img width="817" alt="image" src="https://github.com/user-attachments/assets/8e4f08fb-e87e-46df-b6b3-07c3173824f2" />
